### PR TITLE
Fix Astro build path in GitHub Pages workflow

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -25,8 +25,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BUILD_PATH: "." # default value when not using subfolders
-  # BUILD_PATH: subfolder
+  BUILD_PATH: "docs-site"
 
 jobs:
   build:


### PR DESCRIPTION
Set BUILD_PATH to docs-site where the Astro site actually lives, so npm ci installs the correct dependencies.