### PR TITLE
Fix homepage detection in Hero component

### DIFF
--- a/docs-site/src/components/Hero.astro
+++ b/docs-site/src/components/Hero.astro
@@ -2,7 +2,7 @@
 import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/Hero.astro';
 
-const isHomePage = Astro.props.slug === '';
+const isHomePage = Astro.props.slug === '' || Astro.props.slug === 'index' || Astro.props.id === 'index.mdx';
 ---
 
 {isHomePage ? (


### PR DESCRIPTION
Check for slug === 'index' and id === 'index.mdx' in addition to empty string, as Starlight may use different values.