### PR TITLE
Add compatibility line for runbook proposal target metadata

### DIFF
--- a/src/learning/__tests__/loop.test.ts
+++ b/src/learning/__tests__/loop.test.ts
@@ -116,6 +116,7 @@ services:
     const proposalContent = await readFile(output.proposedRunbookUpdates[0], 'utf-8');
     expect(proposalContent).toContain('Runbook Update Proposal');
     expect(proposalContent).toContain('Checkout API Recovery');
+    expect(proposalContent).toContain('Suggested Target: Checkout API Recovery');
   });
 
   it('applies update suggestions directly to local runbooks in apply mode', async () => {
@@ -201,7 +202,8 @@ services:
               title: 'Checkout DB Pool Exhaustion Mitigation',
               services: ['checkout-api', 'postgres'],
               reasoning: 'No dedicated runbook exists for this failure mode.',
-              contentMarkdown: '# Checkout DB Pool Exhaustion\n\n## Mitigation\n- Scale read replicas.',
+              contentMarkdown:
+                '# Checkout DB Pool Exhaustion\n\n## Mitigation\n- Scale read replicas.',
               confidence: 0.88,
             },
           ],

--- a/src/learning/loop.ts
+++ b/src/learning/loop.ts
@@ -556,6 +556,7 @@ async function applySuggestion(
       '# Runbook Update Proposal',
       '',
       `- Incident: ${context.incidentLabel}`,
+      `- Suggested Target: ${targetTitle}`,
       `- Suggested Target Title: ${targetTitle}`,
       `- Suggested Target Path: ${targetPath}`,
       `- Confidence: ${suggestion.confidence}`,


### PR DESCRIPTION
## Summary
- add a backward-compatible `Suggested Target` line in runbook update proposals
- keep explicit target metadata fields (`Suggested Target Title`, `Suggested Target Path`)
- update learning-loop test coverage to assert the compatibility line

## Why
Some downstream checks read the older `Suggested Target` wording. This keeps compatibility while preserving structured title/path output.

## Files
- src/learning/loop.ts
- src/learning/__tests__/loop.test.ts

## Validation
- npm run test -- src/learning/__tests__/loop.test.ts
