### PR TITLE
Add Claude hook integration commands and event persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,25 @@ runbook slack-gateway --mode http --port 3001
 
 See setup details in [docs/SLACK_GATEWAY.md](./docs/SLACK_GATEWAY.md).
 
+### `runbook integrations claude enable`
+
+Install Claude Code hooks into `.claude/settings.json` so active Claude sessions stream hook events into Runbook artifacts.
+
+```bash
+# Project-scoped install (recommended)
+runbook integrations claude enable
+
+# Optional: include Notification events too
+runbook integrations claude enable --include-notifications
+
+# Check installation
+runbook integrations claude status
+```
+
+Hook events are persisted under:
+- `.runbook/hooks/claude/latest.json`
+- `.runbook/hooks/claude/sessions/<session-id>/events.ndjson`
+
 ## Configuration
 
 Create `.runbook/config.yaml`:

--- a/src/integrations/__tests__/claude-hooks.test.ts
+++ b/src/integrations/__tests__/claude-hooks.test.ts
@@ -1,0 +1,211 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync, mkdtempSync } from 'fs';
+import { describe, expect, it } from 'vitest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  getClaudeHookStatus,
+  installClaudeHooks,
+  persistClaudeHookEvent,
+  uninstallClaudeHooks,
+} from '../claude-hooks';
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+}
+
+function getCommandsForEvent(
+  settings: Record<string, unknown>,
+  event: string
+): Array<{ matcher: string; command: string }> {
+  const hooks = settings.hooks as Record<string, unknown>;
+  const eventMatchers = hooks?.[event];
+  if (!Array.isArray(eventMatchers)) {
+    return [];
+  }
+
+  const commands: Array<{ matcher: string; command: string }> = [];
+  for (const matcherEntry of eventMatchers) {
+    const matcherObj = matcherEntry as Record<string, unknown>;
+    const matcher = typeof matcherObj.matcher === 'string' ? matcherObj.matcher : '';
+    const hooksForMatcher = matcherObj.hooks;
+    if (!Array.isArray(hooksForMatcher)) {
+      continue;
+    }
+    for (const hook of hooksForMatcher) {
+      const hookObj = hook as Record<string, unknown>;
+      if (typeof hookObj.command === 'string') {
+        commands.push({ matcher, command: hookObj.command });
+      }
+    }
+  }
+
+  return commands;
+}
+
+function createTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'runbook-claude-hooks-'));
+}
+
+describe('claude-hooks integration', () => {
+  it('installs Claude hooks into project settings.json', async () => {
+    const root = createTempDir();
+    const result = await installClaudeHooks({
+      cwd: root,
+      runbookCommand: 'runbook',
+    });
+
+    expect(result.addedHooks).toBe(7);
+    expect(result.eventsUpdated).toEqual([
+      'SessionStart',
+      'UserPromptSubmit',
+      'PreToolUse',
+      'PostToolUse',
+      'Stop',
+      'SubagentStop',
+      'PreCompact',
+    ]);
+    expect(existsSync(result.settingsPath)).toBe(true);
+
+    const settings = readJson(result.settingsPath);
+    const command = 'runbook integrations claude hook';
+
+    expect(getCommandsForEvent(settings, 'SessionStart')).toContainEqual({ matcher: '', command });
+    expect(getCommandsForEvent(settings, 'UserPromptSubmit')).toContainEqual({
+      matcher: '',
+      command,
+    });
+    expect(getCommandsForEvent(settings, 'PreToolUse')).toContainEqual({
+      matcher: '.*',
+      command,
+    });
+    expect(getCommandsForEvent(settings, 'PostToolUse')).toContainEqual({
+      matcher: '.*',
+      command,
+    });
+    expect(getCommandsForEvent(settings, 'Stop')).toContainEqual({ matcher: '', command });
+    expect(getCommandsForEvent(settings, 'SubagentStop')).toContainEqual({
+      matcher: '',
+      command,
+    });
+    expect(getCommandsForEvent(settings, 'PreCompact')).toContainEqual({ matcher: '', command });
+  });
+
+  it('is idempotent when run repeatedly', async () => {
+    const root = createTempDir();
+
+    const first = await installClaudeHooks({
+      cwd: root,
+      runbookCommand: 'runbook',
+    });
+    const second = await installClaudeHooks({
+      cwd: root,
+      runbookCommand: 'runbook',
+    });
+
+    expect(first.addedHooks).toBe(7);
+    expect(second.addedHooks).toBe(0);
+
+    const settings = readJson(first.settingsPath);
+    const allCommands = [
+      ...getCommandsForEvent(settings, 'SessionStart'),
+      ...getCommandsForEvent(settings, 'UserPromptSubmit'),
+      ...getCommandsForEvent(settings, 'PreToolUse'),
+      ...getCommandsForEvent(settings, 'PostToolUse'),
+      ...getCommandsForEvent(settings, 'Stop'),
+      ...getCommandsForEvent(settings, 'SubagentStop'),
+      ...getCommandsForEvent(settings, 'PreCompact'),
+    ].filter((item) => item.command === 'runbook integrations claude hook');
+
+    expect(allCommands).toHaveLength(7);
+  });
+
+  it('preserves existing user hooks and removes only runbook hooks on uninstall', async () => {
+    const root = createTempDir();
+    const claudeDir = join(root, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = join(claudeDir, 'settings.json');
+
+    writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          hooks: {
+            Stop: [
+              {
+                matcher: '',
+                hooks: [{ type: 'command', command: 'echo "user stop hook"' }],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    await installClaudeHooks({ cwd: root, runbookCommand: 'runbook' });
+
+    const installed = readJson(settingsPath);
+    expect(getCommandsForEvent(installed, 'Stop')).toContainEqual({
+      matcher: '',
+      command: 'echo "user stop hook"',
+    });
+    expect(getCommandsForEvent(installed, 'Stop')).toContainEqual({
+      matcher: '',
+      command: 'runbook integrations claude hook',
+    });
+
+    const removed = await uninstallClaudeHooks({ cwd: root, runbookCommand: 'runbook' });
+    expect(removed.removedHooks).toBeGreaterThan(0);
+
+    const afterUninstall = readJson(settingsPath);
+    const stopCommands = getCommandsForEvent(afterUninstall, 'Stop');
+    expect(stopCommands).toContainEqual({ matcher: '', command: 'echo "user stop hook"' });
+    expect(stopCommands.some((item) => item.command === 'runbook integrations claude hook')).toBe(
+      false
+    );
+  });
+
+  it('reports hook status accurately', async () => {
+    const root = createTempDir();
+    const before = await getClaudeHookStatus({ cwd: root, runbookCommand: 'runbook' });
+    expect(before.exists).toBe(false);
+    expect(before.installed).toBe(false);
+
+    await installClaudeHooks({ cwd: root, runbookCommand: 'runbook' });
+    const after = await getClaudeHookStatus({ cwd: root, runbookCommand: 'runbook' });
+
+    expect(after.exists).toBe(true);
+    expect(after.installed).toBe(true);
+    expect(after.installedHooks).toBe(7);
+    expect(after.eventCounts.SessionStart).toBe(1);
+    expect(after.eventCounts.Stop).toBe(1);
+  });
+
+  it('persists hook payloads as NDJSON artifacts', async () => {
+    const root = createTempDir();
+
+    const saved = await persistClaudeHookEvent(
+      {
+        session_id: 'sess-123',
+        hook_event_name: 'UserPromptSubmit',
+        cwd: root,
+        transcript_path: '/tmp/transcript.jsonl',
+        prompt: 'Investigate checkout latency spike',
+      },
+      { now: new Date('2026-02-11T12:00:00.000Z') }
+    );
+
+    expect(existsSync(saved.eventsFile)).toBe(true);
+    expect(existsSync(saved.latestEventFile)).toBe(true);
+    expect(existsSync(join(saved.sessionDir, 'last-prompt.txt'))).toBe(true);
+
+    const lines = readFileSync(saved.eventsFile, 'utf-8').trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+
+    const event = JSON.parse(lines[0]) as Record<string, unknown>;
+    expect(event.eventName).toBe('UserPromptSubmit');
+    expect(event.sessionId).toBe('sess-123');
+    expect(event.observedAt).toBe('2026-02-11T12:00:00.000Z');
+  });
+});

--- a/src/integrations/claude-hooks.ts
+++ b/src/integrations/claude-hooks.ts
@@ -1,0 +1,508 @@
+import { existsSync } from 'fs';
+import { appendFile, mkdir, readFile, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+export type ClaudeSettingsScope = 'project' | 'user';
+
+export type ClaudeHookEventName =
+  | 'SessionStart'
+  | 'UserPromptSubmit'
+  | 'PreToolUse'
+  | 'PostToolUse'
+  | 'Stop'
+  | 'SubagentStop'
+  | 'PreCompact'
+  | 'Notification';
+
+interface ClaudeHookEventConfig {
+  event: ClaudeHookEventName;
+  matcher: string;
+}
+
+interface ClaudeHookEntry extends Record<string, unknown> {
+  type?: string;
+  command?: string;
+}
+
+interface ClaudeHookMatcher extends Record<string, unknown> {
+  matcher: string;
+  hooks: ClaudeHookEntry[];
+}
+
+export interface InstallClaudeHooksOptions {
+  scope?: ClaudeSettingsScope;
+  cwd?: string;
+  homeDir?: string;
+  runbookCommand?: string;
+  includeNotifications?: boolean;
+}
+
+export interface InstallClaudeHooksResult {
+  settingsPath: string;
+  hookCommand: string;
+  addedHooks: number;
+  eventsUpdated: ClaudeHookEventName[];
+}
+
+export interface UninstallClaudeHooksOptions {
+  scope?: ClaudeSettingsScope;
+  cwd?: string;
+  homeDir?: string;
+  runbookCommand?: string;
+}
+
+export interface UninstallClaudeHooksResult {
+  settingsPath: string;
+  removedHooks: number;
+  eventsUpdated: ClaudeHookEventName[];
+}
+
+export interface ClaudeHookStatusOptions {
+  scope?: ClaudeSettingsScope;
+  cwd?: string;
+  homeDir?: string;
+  runbookCommand?: string;
+}
+
+export interface ClaudeHookStatusResult {
+  settingsPath: string;
+  exists: boolean;
+  installed: boolean;
+  installedHooks: number;
+  eventCounts: Partial<Record<ClaudeHookEventName, number>>;
+}
+
+export interface PersistClaudeHookEventOptions {
+  projectDir?: string;
+  now?: Date;
+}
+
+export interface PersistClaudeHookEventResult {
+  baseDir: string;
+  sessionDir: string;
+  eventsFile: string;
+  latestEventFile: string;
+  sessionId: string;
+  eventName: string;
+}
+
+export interface HandleClaudeHookStdinResult {
+  handled: boolean;
+  reason?: 'empty_stdin' | 'invalid_json' | 'persist_error';
+  error?: string;
+  persistence?: PersistClaudeHookEventResult;
+}
+
+const DEFAULT_EVENTS: ClaudeHookEventConfig[] = [
+  { event: 'SessionStart', matcher: '' },
+  { event: 'UserPromptSubmit', matcher: '' },
+  { event: 'PreToolUse', matcher: '.*' },
+  { event: 'PostToolUse', matcher: '.*' },
+  { event: 'Stop', matcher: '' },
+  { event: 'SubagentStop', matcher: '' },
+  { event: 'PreCompact', matcher: '' },
+];
+
+const NOTIFICATION_EVENT: ClaudeHookEventConfig = { event: 'Notification', matcher: '.*' };
+
+const CLAUDE_HOOK_COMMAND_SUFFIX = 'integrations claude hook';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function trimCommand(value: string | undefined): string {
+  const fallback = 'runbook';
+  if (!value) {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function buildHookCommand(runbookCommand: string | undefined): string {
+  return `${trimCommand(runbookCommand)} ${CLAUDE_HOOK_COMMAND_SUFFIX}`;
+}
+
+function isRunbookClaudeHookCommand(command: string, runbookCommand?: string): boolean {
+  const expected = buildHookCommand(runbookCommand);
+  if (command.trim() === expected) {
+    return true;
+  }
+  return command.includes(` ${CLAUDE_HOOK_COMMAND_SUFFIX}`) || command.startsWith(expected);
+}
+
+function getEvents(options: { includeNotifications?: boolean }): ClaudeHookEventConfig[] {
+  if (!options.includeNotifications) {
+    return DEFAULT_EVENTS;
+  }
+  return [...DEFAULT_EVENTS, NOTIFICATION_EVENT];
+}
+
+function resolveProjectRoot(startDir: string): string {
+  let current = resolve(startDir);
+
+  while (!existsSync(join(current, '.git')) && !existsSync(join(current, '.claude'))) {
+    const parent = dirname(current);
+    if (parent === current) {
+      return resolve(startDir);
+    }
+    current = parent;
+  }
+
+  return current;
+}
+
+function getSettingsPath(options: {
+  scope?: ClaudeSettingsScope;
+  cwd?: string;
+  homeDir?: string;
+}): string {
+  const scope = options.scope || 'project';
+  if (scope === 'user') {
+    return join(options.homeDir || homedir(), '.claude', 'settings.json');
+  }
+  const projectRoot = resolveProjectRoot(options.cwd || process.cwd());
+  return join(projectRoot, '.claude', 'settings.json');
+}
+
+async function loadSettings(settingsPath: string): Promise<Record<string, unknown>> {
+  if (!existsSync(settingsPath)) {
+    return {};
+  }
+
+  const content = await readFile(settingsPath, 'utf-8');
+  if (content.trim().length === 0) {
+    return {};
+  }
+
+  const parsed = JSON.parse(content);
+  if (!isRecord(parsed)) {
+    throw new Error('Claude settings.json must contain a JSON object');
+  }
+  return parsed;
+}
+
+async function writeSettings(
+  settingsPath: string,
+  settings: Record<string, unknown>
+): Promise<void> {
+  await mkdir(dirname(settingsPath), { recursive: true });
+  await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf-8');
+}
+
+function readEventMatchers(
+  hooks: Record<string, unknown>,
+  event: ClaudeHookEventName
+): ClaudeHookMatcher[] {
+  const raw = hooks[event];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const normalized: ClaudeHookMatcher[] = [];
+  for (const item of raw) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const matcher = typeof item.matcher === 'string' ? item.matcher : '';
+    const hooksRaw = Array.isArray(item.hooks) ? item.hooks : [];
+    const entries: ClaudeHookEntry[] = [];
+    for (const entry of hooksRaw) {
+      if (isRecord(entry)) {
+        entries.push({ ...entry });
+      }
+    }
+    normalized.push({ ...item, matcher, hooks: entries });
+  }
+  return normalized;
+}
+
+function addCommandToMatchers(
+  matchers: ClaudeHookMatcher[],
+  matcherName: string,
+  command: string
+): { matchers: ClaudeHookMatcher[]; added: boolean } {
+  for (let i = 0; i < matchers.length; i++) {
+    if (matchers[i].matcher !== matcherName) {
+      continue;
+    }
+
+    const alreadyExists = matchers[i].hooks.some((hook) => hook.command === command);
+    if (alreadyExists) {
+      return { matchers, added: false };
+    }
+
+    const next = [...matchers];
+    next[i] = {
+      ...next[i],
+      hooks: [...next[i].hooks, { type: 'command', command }],
+    };
+    return { matchers: next, added: true };
+  }
+
+  return {
+    matchers: [...matchers, { matcher: matcherName, hooks: [{ type: 'command', command }] }],
+    added: true,
+  };
+}
+
+function removeCommandFromMatchers(
+  matchers: ClaudeHookMatcher[],
+  runbookCommand?: string
+): { matchers: ClaudeHookMatcher[]; removed: number } {
+  const next: ClaudeHookMatcher[] = [];
+  let removed = 0;
+
+  for (const matcher of matchers) {
+    const filteredHooks = matcher.hooks.filter((entry) => {
+      const command = typeof entry.command === 'string' ? entry.command : '';
+      const shouldRemove =
+        command.length > 0 && isRunbookClaudeHookCommand(command, runbookCommand);
+      if (shouldRemove) {
+        removed++;
+      }
+      return !shouldRemove;
+    });
+
+    if (filteredHooks.length > 0) {
+      next.push({ ...matcher, hooks: filteredHooks });
+    }
+  }
+
+  return { matchers: next, removed };
+}
+
+function countCommands(
+  matchers: ClaudeHookMatcher[],
+  runbookCommand?: string
+): { total: number; matching: number } {
+  let total = 0;
+  let matching = 0;
+  for (const matcher of matchers) {
+    for (const entry of matcher.hooks) {
+      if (typeof entry.command !== 'string') {
+        continue;
+      }
+      total++;
+      if (isRunbookClaudeHookCommand(entry.command, runbookCommand)) {
+        matching++;
+      }
+    }
+  }
+  return { total, matching };
+}
+
+export async function installClaudeHooks(
+  options: InstallClaudeHooksOptions = {}
+): Promise<InstallClaudeHooksResult> {
+  const settingsPath = getSettingsPath(options);
+  const hookCommand = buildHookCommand(options.runbookCommand);
+  const settings = await loadSettings(settingsPath);
+  const hooks = isRecord(settings.hooks) ? { ...settings.hooks } : {};
+  const events = getEvents({ includeNotifications: options.includeNotifications });
+
+  let addedHooks = 0;
+  const eventsUpdated: ClaudeHookEventName[] = [];
+
+  for (const config of events) {
+    const matchers = readEventMatchers(hooks, config.event);
+    const result = addCommandToMatchers(matchers, config.matcher, hookCommand);
+    hooks[config.event] = result.matchers;
+    if (result.added) {
+      addedHooks++;
+      eventsUpdated.push(config.event);
+    }
+  }
+
+  if (addedHooks > 0 || !existsSync(settingsPath)) {
+    settings.hooks = hooks;
+    await writeSettings(settingsPath, settings);
+  }
+
+  return {
+    settingsPath,
+    hookCommand,
+    addedHooks,
+    eventsUpdated,
+  };
+}
+
+export async function uninstallClaudeHooks(
+  options: UninstallClaudeHooksOptions = {}
+): Promise<UninstallClaudeHooksResult> {
+  const settingsPath = getSettingsPath(options);
+  if (!existsSync(settingsPath)) {
+    return { settingsPath, removedHooks: 0, eventsUpdated: [] };
+  }
+
+  const settings = await loadSettings(settingsPath);
+  const hooks = isRecord(settings.hooks) ? { ...settings.hooks } : {};
+  const events = getEvents({ includeNotifications: true });
+
+  let removedHooks = 0;
+  const eventsUpdated: ClaudeHookEventName[] = [];
+
+  for (const config of events) {
+    const matchers = readEventMatchers(hooks, config.event);
+    const result = removeCommandFromMatchers(matchers, options.runbookCommand);
+    hooks[config.event] = result.matchers;
+    if (result.removed > 0) {
+      removedHooks += result.removed;
+      eventsUpdated.push(config.event);
+    }
+  }
+
+  if (removedHooks > 0) {
+    settings.hooks = hooks;
+    await writeSettings(settingsPath, settings);
+  }
+
+  return {
+    settingsPath,
+    removedHooks,
+    eventsUpdated,
+  };
+}
+
+export async function getClaudeHookStatus(
+  options: ClaudeHookStatusOptions = {}
+): Promise<ClaudeHookStatusResult> {
+  const settingsPath = getSettingsPath(options);
+  if (!existsSync(settingsPath)) {
+    return {
+      settingsPath,
+      exists: false,
+      installed: false,
+      installedHooks: 0,
+      eventCounts: {},
+    };
+  }
+
+  const settings = await loadSettings(settingsPath);
+  const hooks = isRecord(settings.hooks) ? settings.hooks : {};
+  const events = getEvents({ includeNotifications: true });
+  const eventCounts: Partial<Record<ClaudeHookEventName, number>> = {};
+  let installedHooks = 0;
+
+  for (const config of events) {
+    const matchers = readEventMatchers(hooks, config.event);
+    const { matching } = countCommands(matchers, options.runbookCommand);
+    if (matching > 0) {
+      eventCounts[config.event] = matching;
+      installedHooks += matching;
+    }
+  }
+
+  return {
+    settingsPath,
+    exists: true,
+    installed: installedHooks > 0,
+    installedHooks,
+    eventCounts,
+  };
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function sanitizeSessionId(sessionId: string): string {
+  return sessionId.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+export async function persistClaudeHookEvent(
+  payload: unknown,
+  options: PersistClaudeHookEventOptions = {}
+): Promise<PersistClaudeHookEventResult> {
+  if (!isRecord(payload)) {
+    throw new Error('Hook payload must be a JSON object');
+  }
+
+  const payloadCwd = asString(payload.cwd);
+  const projectDir = resolveProjectRoot(options.projectDir || payloadCwd || process.cwd());
+  const sessionId = asString(payload.session_id) || 'unknown-session';
+  const eventName = asString(payload.hook_event_name) || 'UnknownEvent';
+  const now = options.now || new Date();
+
+  const baseDir = join(projectDir, '.runbook', 'hooks', 'claude');
+  const sessionDir = join(baseDir, 'sessions', sanitizeSessionId(sessionId));
+  const eventsFile = join(sessionDir, 'events.ndjson');
+  const latestEventFile = join(baseDir, 'latest.json');
+
+  await mkdir(sessionDir, { recursive: true });
+
+  const eventRecord = {
+    observedAt: now.toISOString(),
+    sessionId,
+    eventName,
+    cwd: payloadCwd || projectDir,
+    transcriptPath: asString(payload.transcript_path) || null,
+    payload,
+  };
+
+  await appendFile(eventsFile, `${JSON.stringify(eventRecord)}\n`, 'utf-8');
+  await writeFile(latestEventFile, `${JSON.stringify(eventRecord, null, 2)}\n`, 'utf-8');
+
+  const prompt = asString(payload.prompt);
+  if (prompt) {
+    await writeFile(join(sessionDir, 'last-prompt.txt'), `${prompt}\n`, 'utf-8');
+  }
+
+  return {
+    baseDir,
+    sessionDir,
+    eventsFile,
+    latestEventFile,
+    sessionId,
+    eventName,
+  };
+}
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    return '';
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+export async function handleClaudeHookStdin(
+  options: PersistClaudeHookEventOptions = {}
+): Promise<HandleClaudeHookStdinResult> {
+  const input = await readStdin();
+  if (input.trim().length === 0) {
+    return { handled: false, reason: 'empty_stdin' };
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(input);
+  } catch (error) {
+    return {
+      handled: false,
+      reason: 'invalid_json',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  try {
+    const persistence = await persistClaudeHookEvent(payload, options);
+    return { handled: true, persistence };
+  } catch (error) {
+    return {
+      handled: false,
+      reason: 'persist_error',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add Claude Code hook integration support under `runbook integrations claude`
- support `enable`, `status`, `disable`, and internal `hook` commands
- install/remove hook commands in `.claude/settings.json` (project or user scope)
- persist Claude hook payloads into Runbook artifacts under `.runbook/hooks/claude`
- document setup and usage in README

## Commands Added
- `runbook integrations claude enable`
- `runbook integrations claude status`
- `runbook integrations claude disable`
- `runbook integrations claude hook` (internal)

## Files
- `src/integrations/claude-hooks.ts`
- `src/integrations/__tests__/claude-hooks.test.ts`
- `src/cli.tsx`
- `README.md`

## Validation
- `npm run test -- src/integrations/__tests__/claude-hooks.test.ts`
