### PR TITLE
Add pluggable Claude session storage and learning-loop ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ Hook events are persisted under:
 - `.runbook/hooks/claude/latest.json`
 - `.runbook/hooks/claude/sessions/<session-id>/events.ndjson`
 
+Generate learning artifacts directly from a stored Claude session:
+
+```bash
+runbook integrations claude learn <session-id> --incident-id PD-123
+```
+
+See storage and ingestion architecture in [docs/CLAUDE_SESSION_STORAGE_PROPOSAL.md](./docs/CLAUDE_SESSION_STORAGE_PROPOSAL.md).
+
 ## Configuration
 
 Create `.runbook/config.yaml`:
@@ -223,6 +231,22 @@ knowledge:
       clientSecret: ${GOOGLE_CLIENT_SECRET}
       refreshToken: ${GOOGLE_REFRESH_TOKEN}
       includeSubfolders: true
+
+integrations:
+  claude:
+    sessionStorage:
+      # local | s3
+      backend: local
+      # keep a local copy even if backend is s3
+      mirrorLocal: true
+      localBaseDir: .runbook/hooks/claude
+      s3:
+        bucket: your-runbook-session-logs
+        prefix: runbook/hooks/claude
+        region: us-east-1
+        # optional for MinIO/custom S3-compatible endpoints
+        endpoint: https://s3.amazonaws.com
+        forcePathStyle: false
 ```
 
 See [PLAN.md](./PLAN.md) for full configuration options.

--- a/docs/CLAUDE_SESSION_STORAGE_PROPOSAL.md
+++ b/docs/CLAUDE_SESSION_STORAGE_PROPOSAL.md
@@ -1,0 +1,83 @@
+# Claude Session Storage + Learning Ingestion
+
+## Goal
+
+Let teams using Claude-based coding/on-call agents store session logs in a location they choose, then run Runbook learning loops on those sessions to generate:
+- postmortems
+- runbook updates/proposals
+- new knowledge documents
+
+This makes Runbook usable without forcing teams to change their daily agent tooling.
+
+## Design Summary
+
+### 1) Pluggable storage backend
+
+Runbook persists Claude hook events through a storage abstraction with configurable backend:
+- `local` (default): `.runbook/hooks/claude`
+- `s3`: centralized object storage
+
+Optional `mirrorLocal` keeps local artifacts even when `s3` is the primary backend.
+
+### 2) Hook persistence flow
+
+Claude hook callback (`runbook integrations claude hook`) now:
+1. loads Runbook config
+2. builds storage backend from `integrations.claude.sessionStorage`
+3. persists event via selected backend(s)
+
+### 3) Learning-loop ingestion from session logs
+
+New command:
+
+```bash
+runbook integrations claude learn <session-id> [--incident-id <id>] [--query <text>] [--apply-runbook-updates]
+```
+
+This command:
+1. loads stored session events from configured backend
+2. converts them into learning timeline events
+3. synthesizes investigation metadata
+4. runs the existing learning loop pipeline
+
+## Config
+
+```yaml
+integrations:
+  claude:
+    sessionStorage:
+      backend: local # local | s3
+      mirrorLocal: true
+      localBaseDir: .runbook/hooks/claude
+      s3:
+        bucket: your-runbook-session-logs
+        prefix: runbook/hooks/claude
+        region: us-east-1
+        endpoint: https://s3.amazonaws.com # optional
+        forcePathStyle: false
+```
+
+Validation:
+- if `backend: s3`, `s3.bucket` is required.
+
+## Why This Enables Adoption
+
+- Works with existing Claude workflows; no custom UI required.
+- Supports centralized storage for multi-team auditability.
+- Keeps default local behavior for zero-friction setup.
+- Connects agent sessions directly to postmortem/runbook learning outputs.
+
+## Roadmap
+
+### Implemented in this phase
+- Storage abstraction
+- `local` backend
+- `s3` backend
+- hook persistence routing through configured backend
+- learning-loop ingestion command for stored sessions
+
+### Next phases
+- GitHub backend (repo issues/artifacts/JSONL blobs)
+- retention policy + compaction
+- PII redaction hooks before persist
+- cross-session incident clustering and retrieval

--- a/src/integrations/__tests__/claude-session-store.test.ts
+++ b/src/integrations/__tests__/claude-session-store.test.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from 'fs';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { createClaudeSessionStorageFromConfig } from '../claude-session-store';
+import { DEFAULT_CONFIG, type Config } from '../../utils/config';
+
+function cloneConfig(): Config {
+  return JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as Config;
+}
+
+describe('claude-session-store', () => {
+  it('persists and retrieves session events with local backend', async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'runbook-session-store-local-'));
+    const config = cloneConfig();
+    config.integrations.claude.sessionStorage.backend = 'local';
+    config.integrations.claude.sessionStorage.localBaseDir = '.runbook/hooks/claude';
+
+    const storage = createClaudeSessionStorageFromConfig(config, { projectDir });
+    const persisted = await storage.persistEvent(
+      {
+        observedAt: '2026-02-11T18:00:00.000Z',
+        sessionId: 'sess-local-1',
+        eventName: 'UserPromptSubmit',
+        cwd: projectDir,
+        transcriptPath: null,
+        payload: {
+          prompt: 'Investigate checkout latency',
+        },
+      },
+      { prompt: 'Investigate checkout latency' }
+    );
+
+    expect(persisted.primary.backend).toBe('local');
+    expect(existsSync(persisted.primary.eventsLocation)).toBe(true);
+    expect(existsSync(join(projectDir, '.runbook', 'hooks', 'claude', 'latest.json'))).toBe(true);
+
+    const lines = readFileSync(persisted.primary.eventsLocation, 'utf-8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    expect(lines).toHaveLength(1);
+
+    const events = await storage.getSessionEvents('sess-local-1');
+    expect(events).toHaveLength(1);
+    expect(events[0].eventName).toBe('UserPromptSubmit');
+    expect(events[0].sessionId).toBe('sess-local-1');
+  });
+
+  it('rejects s3 backend when bucket is not configured', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'runbook-session-store-s3-'));
+    const config = cloneConfig();
+    config.integrations.claude.sessionStorage.backend = 's3';
+    config.integrations.claude.sessionStorage.s3.bucket = undefined;
+
+    expect(() => createClaudeSessionStorageFromConfig(config, { projectDir })).toThrow(
+      /no bucket configured/i
+    );
+  });
+});

--- a/src/integrations/claude-session-store.ts
+++ b/src/integrations/claude-session-store.ts
@@ -1,0 +1,391 @@
+import { existsSync } from 'fs';
+import { appendFile, mkdir, readFile, writeFile } from 'fs/promises';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { isAbsolute, join } from 'path';
+import type { Config } from '../utils/config';
+
+export type ClaudeSessionStorageBackend = 'local' | 's3';
+
+export interface ClaudeSessionEventRecord {
+  observedAt: string;
+  sessionId: string;
+  eventName: string;
+  cwd: string;
+  transcriptPath: string | null;
+  payload: Record<string, unknown>;
+}
+
+export interface ClaudeSessionStorageDestination {
+  backend: ClaudeSessionStorageBackend;
+  baseLocation: string;
+  sessionLocation: string;
+  eventsLocation: string;
+  latestLocation: string;
+}
+
+export interface ClaudeSessionPersistResult {
+  primary: ClaudeSessionStorageDestination;
+  mirrors: ClaudeSessionStorageDestination[];
+}
+
+export interface ClaudeSessionStorage {
+  persistEvent(
+    event: ClaudeSessionEventRecord,
+    options?: { prompt?: string }
+  ): Promise<ClaudeSessionPersistResult>;
+  getSessionEvents(sessionId: string): Promise<ClaudeSessionEventRecord[]>;
+}
+
+export interface CreateClaudeSessionStorageOptions {
+  projectDir?: string;
+}
+
+interface ClaudeS3StorageConfig {
+  bucket?: string;
+  prefix: string;
+  region?: string;
+  endpoint?: string;
+  forcePathStyle: boolean;
+}
+
+interface ClaudeSessionStorageConfig {
+  backend: ClaudeSessionStorageBackend;
+  mirrorLocal: boolean;
+  localBaseDir: string;
+  s3: ClaudeS3StorageConfig;
+}
+
+interface SessionBackend {
+  kind: ClaudeSessionStorageBackend;
+  persistEvent(
+    event: ClaudeSessionEventRecord,
+    options?: { prompt?: string }
+  ): Promise<ClaudeSessionStorageDestination>;
+  getSessionEvents(sessionId: string): Promise<ClaudeSessionEventRecord[]>;
+}
+
+function sanitizeSessionId(sessionId: string): string {
+  return sessionId.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+function normalizePrefix(prefix: string): string {
+  return prefix
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join('/');
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseEventLine(line: string): ClaudeSessionEventRecord | null {
+  try {
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    const observedAt = typeof parsed.observedAt === 'string' ? parsed.observedAt : '';
+    const sessionId = typeof parsed.sessionId === 'string' ? parsed.sessionId : '';
+    const eventName = typeof parsed.eventName === 'string' ? parsed.eventName : '';
+    const cwd = typeof parsed.cwd === 'string' ? parsed.cwd : '';
+    const transcriptPath =
+      typeof parsed.transcriptPath === 'string'
+        ? parsed.transcriptPath
+        : parsed.transcriptPath === null
+          ? null
+          : null;
+    const payload = asRecord(parsed.payload);
+
+    if (!observedAt || !sessionId || !eventName || !cwd || !payload) {
+      return null;
+    }
+
+    return {
+      observedAt,
+      sessionId,
+      eventName,
+      cwd,
+      transcriptPath,
+      payload,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function resolveLocalBaseDir(projectDir: string, localBaseDir: string): string {
+  if (isAbsolute(localBaseDir)) {
+    return localBaseDir;
+  }
+  return join(projectDir, localBaseDir);
+}
+
+function createLocalBackend(baseDir: string): SessionBackend {
+  return {
+    kind: 'local',
+    async persistEvent(event, options) {
+      const sessionDir = join(baseDir, 'sessions', sanitizeSessionId(event.sessionId));
+      const eventsFile = join(sessionDir, 'events.ndjson');
+      const latestEventFile = join(baseDir, 'latest.json');
+
+      await mkdir(sessionDir, { recursive: true });
+      await appendFile(eventsFile, `${JSON.stringify(event)}\n`, 'utf-8');
+      await writeFile(latestEventFile, `${JSON.stringify(event, null, 2)}\n`, 'utf-8');
+
+      if (options?.prompt) {
+        await writeFile(join(sessionDir, 'last-prompt.txt'), `${options.prompt}\n`, 'utf-8');
+      }
+
+      return {
+        backend: 'local',
+        baseLocation: baseDir,
+        sessionLocation: sessionDir,
+        eventsLocation: eventsFile,
+        latestLocation: latestEventFile,
+      };
+    },
+    async getSessionEvents(sessionId) {
+      const eventsFile = join(baseDir, 'sessions', sanitizeSessionId(sessionId), 'events.ndjson');
+      if (!existsSync(eventsFile)) {
+        return [];
+      }
+
+      const content = await readFile(eventsFile, 'utf-8');
+      const events: ClaudeSessionEventRecord[] = [];
+      for (const line of content
+        .split('\n')
+        .map((item) => item.trim())
+        .filter(Boolean)) {
+        const event = parseEventLine(line);
+        if (event) {
+          events.push(event);
+        }
+      }
+      return events;
+    },
+  };
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const candidate = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  if (candidate.name === 'NoSuchKey' || candidate.name === 'NotFound') {
+    return true;
+  }
+  if (candidate.$metadata?.httpStatusCode === 404) {
+    return true;
+  }
+  return false;
+}
+
+async function bodyToString(body: unknown): Promise<string> {
+  if (!body) {
+    return '';
+  }
+
+  const withTransform = body as { transformToString?: () => Promise<string> };
+  if (typeof withTransform.transformToString === 'function') {
+    return withTransform.transformToString();
+  }
+
+  const asyncIterable = body as AsyncIterable<unknown>;
+  if (typeof asyncIterable[Symbol.asyncIterator] === 'function') {
+    const chunks: Buffer[] = [];
+    for await (const chunk of asyncIterable) {
+      if (typeof chunk === 'string') {
+        chunks.push(Buffer.from(chunk, 'utf-8'));
+      } else if (chunk instanceof Uint8Array) {
+        chunks.push(Buffer.from(chunk));
+      } else if (chunk instanceof ArrayBuffer) {
+        chunks.push(Buffer.from(new Uint8Array(chunk)));
+      } else {
+        chunks.push(Buffer.from(String(chunk), 'utf-8'));
+      }
+    }
+    return Buffer.concat(chunks).toString('utf-8');
+  }
+
+  return '';
+}
+
+function createS3Backend(config: ClaudeS3StorageConfig): SessionBackend {
+  if (!config.bucket) {
+    throw new Error('S3 backend selected for Claude session storage but no bucket configured.');
+  }
+
+  const prefix = normalizePrefix(config.prefix);
+  const client = new S3Client({
+    region: config.region,
+    endpoint: config.endpoint,
+    forcePathStyle: config.forcePathStyle,
+  });
+
+  function keyForSessionEvents(sessionId: string): string {
+    const suffix = `sessions/${sanitizeSessionId(sessionId)}/events.ndjson`;
+    return prefix ? `${prefix}/${suffix}` : suffix;
+  }
+
+  function keyForSessionPrompt(sessionId: string): string {
+    const suffix = `sessions/${sanitizeSessionId(sessionId)}/last-prompt.txt`;
+    return prefix ? `${prefix}/${suffix}` : suffix;
+  }
+
+  function keyForLatest(): string {
+    return prefix ? `${prefix}/latest.json` : 'latest.json';
+  }
+
+  async function getObjectTextOptional(key: string): Promise<string> {
+    try {
+      const response = await client.send(
+        new GetObjectCommand({
+          Bucket: config.bucket,
+          Key: key,
+        })
+      );
+      return bodyToString(response.Body);
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return '';
+      }
+      throw error;
+    }
+  }
+
+  return {
+    kind: 's3',
+    async persistEvent(event, options) {
+      const eventsKey = keyForSessionEvents(event.sessionId);
+      const latestKey = keyForLatest();
+      const promptKey = keyForSessionPrompt(event.sessionId);
+      const serialized = JSON.stringify(event);
+
+      const existing = await getObjectTextOptional(eventsKey);
+      const nextEvents =
+        existing.trim().length > 0 ? `${existing.trimEnd()}\n${serialized}\n` : `${serialized}\n`;
+
+      await client.send(
+        new PutObjectCommand({
+          Bucket: config.bucket,
+          Key: eventsKey,
+          Body: nextEvents,
+          ContentType: 'application/x-ndjson',
+        })
+      );
+      await client.send(
+        new PutObjectCommand({
+          Bucket: config.bucket,
+          Key: latestKey,
+          Body: `${JSON.stringify(event, null, 2)}\n`,
+          ContentType: 'application/json',
+        })
+      );
+
+      if (options?.prompt) {
+        await client.send(
+          new PutObjectCommand({
+            Bucket: config.bucket,
+            Key: promptKey,
+            Body: `${options.prompt}\n`,
+            ContentType: 'text/plain; charset=utf-8',
+          })
+        );
+      }
+
+      const baseLocation = `s3://${config.bucket}${prefix ? `/${prefix}` : ''}`;
+      return {
+        backend: 's3',
+        baseLocation,
+        sessionLocation: `${baseLocation}/sessions/${sanitizeSessionId(event.sessionId)}`,
+        eventsLocation: `s3://${config.bucket}/${eventsKey}`,
+        latestLocation: `s3://${config.bucket}/${latestKey}`,
+      };
+    },
+    async getSessionEvents(sessionId) {
+      const eventsKey = keyForSessionEvents(sessionId);
+      const content = await getObjectTextOptional(eventsKey);
+      if (!content.trim()) {
+        return [];
+      }
+
+      const events: ClaudeSessionEventRecord[] = [];
+      for (const line of content
+        .split('\n')
+        .map((item) => item.trim())
+        .filter(Boolean)) {
+        const event = parseEventLine(line);
+        if (event) {
+          events.push(event);
+        }
+      }
+      return events;
+    },
+  };
+}
+
+function normalizeConfig(config: Config): ClaudeSessionStorageConfig {
+  return {
+    backend: config.integrations.claude.sessionStorage.backend,
+    mirrorLocal: config.integrations.claude.sessionStorage.mirrorLocal,
+    localBaseDir: config.integrations.claude.sessionStorage.localBaseDir,
+    s3: {
+      bucket: config.integrations.claude.sessionStorage.s3.bucket,
+      prefix: config.integrations.claude.sessionStorage.s3.prefix,
+      region: config.integrations.claude.sessionStorage.s3.region,
+      endpoint: config.integrations.claude.sessionStorage.s3.endpoint,
+      forcePathStyle: config.integrations.claude.sessionStorage.s3.forcePathStyle,
+    },
+  };
+}
+
+export function createClaudeSessionStorageFromConfig(
+  config: Config,
+  options: CreateClaudeSessionStorageOptions = {}
+): ClaudeSessionStorage {
+  const projectDir = options.projectDir || process.cwd();
+  const normalized = normalizeConfig(config);
+  const localBackend = createLocalBackend(resolveLocalBaseDir(projectDir, normalized.localBaseDir));
+
+  const primary: SessionBackend =
+    normalized.backend === 's3' ? createS3Backend(normalized.s3) : localBackend;
+
+  const mirrorBackends: SessionBackend[] = [];
+  if (normalized.backend === 's3' && normalized.mirrorLocal) {
+    mirrorBackends.push(localBackend);
+  }
+
+  return {
+    async persistEvent(event, persistOptions) {
+      const primaryDestination = await primary.persistEvent(event, persistOptions);
+      const mirrors: ClaudeSessionStorageDestination[] = [];
+
+      for (const mirror of mirrorBackends) {
+        mirrors.push(await mirror.persistEvent(event, persistOptions));
+      }
+
+      return {
+        primary: primaryDestination,
+        mirrors,
+      };
+    },
+    async getSessionEvents(sessionId) {
+      const primaryEvents = await primary.getSessionEvents(sessionId);
+      if (primaryEvents.length > 0) {
+        return primaryEvents;
+      }
+
+      for (const mirror of mirrorBackends) {
+        const fallbackEvents = await mirror.getSessionEvents(sessionId);
+        if (fallbackEvents.length > 0) {
+          return fallbackEvents;
+        }
+      }
+
+      return [];
+    },
+  };
+}

--- a/src/learning/__tests__/claude-session-ingestion.test.ts
+++ b/src/learning/__tests__/claude-session-ingestion.test.ts
@@ -1,0 +1,114 @@
+import { mkdtemp, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  convertClaudeSessionToLearningEvents,
+  runLearningLoopFromClaudeSession,
+  synthesizeInvestigationResultFromClaudeSession,
+} from '../claude-session-ingestion';
+import type { ClaudeSessionEventRecord } from '../../integrations/claude-session-store';
+
+function buildDraftResponse(): string {
+  return JSON.stringify({
+    postmortem: {
+      title: 'Checkout incident from Claude session',
+      severity: 'sev2',
+      summary: 'Checkout failures were diagnosed from collected evidence.',
+      impact: 'Users experienced checkout errors.',
+      detection: 'Detected by synthetic checks and on-call triage.',
+      rootCause: 'DB pool saturation',
+      contributingFactors: ['Missing pool saturation alerts'],
+      timeline: [
+        { timestamp: '2026-02-11T08:00:00Z', event: 'Session started', evidence: 'session' },
+        { timestamp: '2026-02-11T08:03:00Z', event: 'Prompt submitted', evidence: 'prompt' },
+        { timestamp: '2026-02-11T08:10:00Z', event: 'Investigation ended', evidence: 'stop' },
+      ],
+      whatWentWell: ['Rapid timeline reconstruction'],
+      whatDidntGoWell: ['Telemetry context needed manual correlation'],
+      actionItems: [
+        {
+          title: 'Add DB pool saturation monitor',
+          ownerRole: 'sre-oncall',
+          priority: 'P1',
+          dueInDays: 7,
+          category: 'detection',
+          details: 'Alert when checkout DB pool utilization exceeds threshold.',
+        },
+      ],
+      confidenceNotes: 'Derived from prompt/tool sequence in session logs.',
+    },
+    knowledgeSuggestions: [],
+  });
+}
+
+function buildSessionEvents(): ClaudeSessionEventRecord[] {
+  return [
+    {
+      observedAt: '2026-02-11T08:00:00.000Z',
+      sessionId: 'sess-abc',
+      eventName: 'SessionStart',
+      cwd: '/tmp/project',
+      transcriptPath: null,
+      payload: {},
+    },
+    {
+      observedAt: '2026-02-11T08:03:00.000Z',
+      sessionId: 'sess-abc',
+      eventName: 'UserPromptSubmit',
+      cwd: '/tmp/project',
+      transcriptPath: null,
+      payload: {
+        prompt: 'Investigate checkout API failures caused by DB pool exhaustion',
+        service: 'checkout-api',
+      },
+    },
+    {
+      observedAt: '2026-02-11T08:10:00.000Z',
+      sessionId: 'sess-abc',
+      eventName: 'Stop',
+      cwd: '/tmp/project',
+      transcriptPath: null,
+      payload: {
+        root_cause: 'DB pool saturation',
+      },
+    },
+  ];
+}
+
+describe('claude session learning ingestion', () => {
+  it('converts Claude session records into learning events', () => {
+    const events = convertClaudeSessionToLearningEvents(buildSessionEvents());
+    expect(events).toHaveLength(3);
+    expect(events[0].type).toBe('claude_sessionstart');
+    expect(events[1].summary).toContain('prompt=');
+  });
+
+  it('synthesizes investigation metadata from session records', () => {
+    const result = synthesizeInvestigationResultFromClaudeSession({
+      sessionId: 'sess-abc',
+      sessionEvents: buildSessionEvents(),
+    });
+
+    expect(result.query).toContain('Investigate checkout API failures');
+    expect(result.rootCause).toBe('DB pool saturation');
+    expect(result.affectedServices).toContain('checkout-api');
+    expect(result.confidence).toBe('low');
+  });
+
+  it('runs learning loop directly from Claude session events', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'runbook-learning-from-session-'));
+    const output = await runLearningLoopFromClaudeSession({
+      sessionId: 'sess-abc',
+      sessionEvents: buildSessionEvents(),
+      incidentId: 'PD-2026',
+      baseDir,
+      complete: async () => buildDraftResponse(),
+    });
+
+    expect(output.postmortemPath).toContain('postmortem-pd-2026.md');
+    const postmortem = await readFile(output.postmortemPath, 'utf-8');
+    expect(postmortem).toContain('Checkout incident from Claude session');
+    expect(postmortem).toContain('DB pool saturation');
+  });
+});

--- a/src/learning/claude-session-ingestion.ts
+++ b/src/learning/claude-session-ingestion.ts
@@ -1,0 +1,186 @@
+import type { InvestigationResult } from '../agent/investigation-orchestrator';
+import type { ClaudeSessionEventRecord } from '../integrations/claude-session-store';
+import { runLearningLoop, type LearningEvent, type LearningLoopOutput } from './loop';
+
+export interface ClaudeSessionLearningInput {
+  sessionId: string;
+  sessionEvents: ClaudeSessionEventRecord[];
+  complete: (prompt: string) => Promise<string>;
+  incidentId?: string;
+  query?: string;
+  baseDir?: string;
+  applyRunbookUpdates?: boolean;
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item) => asString(item))
+    .filter((item): item is string => Boolean(item))
+    .map((item) => item.toLowerCase());
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function describeEvent(event: ClaudeSessionEventRecord): string {
+  const details: string[] = [];
+  const prompt = asString(event.payload.prompt);
+  if (prompt) {
+    details.push(`prompt="${truncate(prompt.replace(/\s+/g, ' '), 140)}"`);
+  }
+
+  const toolName =
+    asString(event.payload.tool_name) ||
+    asString(event.payload.toolName) ||
+    asString(event.payload.tool);
+  if (toolName) {
+    details.push(`tool=${toolName}`);
+  }
+
+  const status = asString(event.payload.status);
+  if (status) {
+    details.push(`status=${status}`);
+  }
+
+  const errorMessage = asString(event.payload.error);
+  if (errorMessage) {
+    details.push(`error="${truncate(errorMessage, 120)}"`);
+  }
+
+  if (details.length === 0) {
+    return `Claude event ${event.eventName}`;
+  }
+
+  return `Claude ${event.eventName}: ${details.join(' | ')}`;
+}
+
+export function convertClaudeSessionToLearningEvents(
+  sessionEvents: ClaudeSessionEventRecord[]
+): LearningEvent[] {
+  const sorted = [...sessionEvents].sort((a, b) => a.observedAt.localeCompare(b.observedAt));
+  return sorted.map((event) => ({
+    timestamp: event.observedAt,
+    phase: event.eventName.includes('Tool')
+      ? 'tool'
+      : event.eventName === 'Stop' || event.eventName === 'SubagentStop'
+        ? 'conclude'
+        : 'investigate',
+    type: `claude_${event.eventName.toLowerCase()}`,
+    summary: describeEvent(event),
+    details: {
+      sessionId: event.sessionId,
+      eventName: event.eventName,
+      transcriptPath: event.transcriptPath,
+    },
+  }));
+}
+
+function inferQuery(sessionEvents: ClaudeSessionEventRecord[], fallback: string): string {
+  for (const event of sessionEvents) {
+    const prompt = asString(event.payload.prompt);
+    if (prompt) {
+      return prompt;
+    }
+  }
+  return fallback;
+}
+
+function inferAffectedServices(sessionEvents: ClaudeSessionEventRecord[]): string[] {
+  const services = new Set<string>();
+  for (const event of sessionEvents) {
+    const service = asString(event.payload.service);
+    if (service) {
+      services.add(service.toLowerCase());
+    }
+    const serviceList = asStringArray(event.payload.services);
+    for (const item of serviceList) {
+      services.add(item);
+    }
+  }
+  return Array.from(services);
+}
+
+function inferRootCause(sessionEvents: ClaudeSessionEventRecord[]): string | undefined {
+  for (let i = sessionEvents.length - 1; i >= 0; i--) {
+    const payload = sessionEvents[i].payload;
+    const direct = asString(payload.root_cause) || asString(payload.rootCause);
+    if (direct) {
+      return direct;
+    }
+  }
+  return undefined;
+}
+
+function inferDurationMs(sessionEvents: ClaudeSessionEventRecord[]): number {
+  if (sessionEvents.length < 2) {
+    return 0;
+  }
+  const first = new Date(sessionEvents[0].observedAt).getTime();
+  const last = new Date(sessionEvents[sessionEvents.length - 1].observedAt).getTime();
+  if (!Number.isFinite(first) || !Number.isFinite(last) || last < first) {
+    return 0;
+  }
+  return last - first;
+}
+
+export function synthesizeInvestigationResultFromClaudeSession(input: {
+  sessionId: string;
+  sessionEvents: ClaudeSessionEventRecord[];
+  query?: string;
+}): InvestigationResult {
+  const fallbackQuery = `Analyze Claude session ${input.sessionId} and generate incident learnings.`;
+  const query = input.query || inferQuery(input.sessionEvents, fallbackQuery);
+  const affectedServices = inferAffectedServices(input.sessionEvents);
+  const rootCause = inferRootCause(input.sessionEvents);
+  const eventCount = input.sessionEvents.length;
+
+  return {
+    id: `claude-${input.sessionId}`,
+    query,
+    rootCause,
+    affectedServices,
+    confidence: eventCount >= 8 ? 'medium' : 'low',
+    remediationPlan: {
+      steps: [],
+      monitoring: [],
+    },
+    summary: `Synthesized from Claude session ${input.sessionId} (${eventCount} captured hook events).`,
+    durationMs: inferDurationMs(input.sessionEvents),
+  };
+}
+
+export async function runLearningLoopFromClaudeSession(
+  input: ClaudeSessionLearningInput
+): Promise<LearningLoopOutput> {
+  const investigationResult = synthesizeInvestigationResultFromClaudeSession({
+    sessionId: input.sessionId,
+    sessionEvents: input.sessionEvents,
+    query: input.query,
+  });
+  const learningEvents = convertClaudeSessionToLearningEvents(input.sessionEvents);
+
+  return runLearningLoop({
+    result: investigationResult,
+    incidentId: input.incidentId || input.sessionId,
+    query: investigationResult.query,
+    events: learningEvents,
+    complete: input.complete,
+    baseDir: input.baseDir,
+    applyRunbookUpdates: input.applyRunbookUpdates,
+  });
+}


### PR DESCRIPTION
## Summary
- add a pluggable Claude session storage manager with configurable `local` and `s3` backends
- wire Claude hook persistence to use configured storage backend (with optional local mirroring for s3)
- add `runbook integrations claude learn <session-id>` to ingest stored Claude sessions into the learning loop
- add configuration schema + validation for `integrations.claude.sessionStorage`
- add architecture proposal docs and README updates for setup/usage

## Implementation Details
- new module: `src/integrations/claude-session-store.ts`
  - unified interface for persisting and reading session events
  - local backend preserves existing `.runbook/hooks/claude` artifact layout
  - s3 backend writes:
    - `sessions/<session-id>/events.ndjson`
    - `sessions/<session-id>/last-prompt.txt`
    - `latest.json`
- `src/integrations/claude-hooks.ts`
  - `persistClaudeHookEvent` now supports optional injected storage backend
  - hidden hook command can use configured storage while keeping local fallback behavior
- new learning ingestion module: `src/learning/claude-session-ingestion.ts`
  - converts Claude hook events to learning timeline events
  - synthesizes investigation metadata
  - runs existing learning loop pipeline
- CLI:
  - `runbook integrations claude learn <session-id> [--incident-id] [--query] [--apply-runbook-updates]`

## Config
```yaml
integrations:
  claude:
    sessionStorage:
      backend: local # or s3
      mirrorLocal: true
      localBaseDir: .runbook/hooks/claude
      s3:
        bucket: your-runbook-session-logs
        prefix: runbook/hooks/claude
        region: us-east-1
        endpoint: https://s3.amazonaws.com
        forcePathStyle: false
```

## Validation
- `npm run typecheck`
- `npm run test`
