### PR TITLE
Add one-line install script

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+userunbook.ai

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,14 +6,14 @@
     <title>RunbookAI - AI-Powered Incident Response for Modern SRE Teams</title>
     <meta name="description" content="Automate incident investigation with AI. RunbookAI uses hypothesis-driven reasoning to diagnose issues, execute runbooks, and resolve incidents faster. Built for on-call engineers and SRE teams." />
     <meta name="keywords" content="SRE, incident response, AI agent, runbooks, kubernetes, AWS, PagerDuty, OpsGenie, DevOps, on-call, incident management, automation, AIOps" />
-    <link rel="canonical" href="https://runbook-agent.github.io/RunbookAI/" />
+    <link rel="canonical" href="https://userunbook.ai/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://runbook-agent.github.io/RunbookAI/" />
+    <meta property="og:url" content="https://userunbook.ai/" />
     <meta property="og:title" content="RunbookAI - AI-Powered Incident Response" />
     <meta property="og:description" content="Automate incident investigation with AI. Hypothesis-driven reasoning that diagnoses issues and resolves incidents faster." />
-    <meta property="og:image" content="https://runbook-agent.github.io/RunbookAI/assets/og-image.png" />
+    <meta property="og:image" content="https://userunbook.ai/assets/og-image.png" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
@@ -121,6 +121,22 @@
             </svg>
             <span>Star on GitHub</span>
           </a>
+        </div>
+
+        <!-- Install Command -->
+        <div class="hero-install">
+          <div class="install-command">
+            <span class="install-label">Install with one command:</span>
+            <div class="install-box">
+              <code>curl -fsSL https://userunbook.ai/install.sh | bash</code>
+              <button class="install-copy" data-copy="curl -fsSL https://userunbook.ai/install.sh | bash" onclick="copyToClipboard(this)">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                  <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
 
         <!-- Terminal Demo -->

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -421,6 +421,76 @@ body {
   flex-wrap: wrap;
 }
 
+/* Install Command */
+.hero-install {
+  margin-top: var(--space-xl);
+}
+
+.install-command {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.install-label {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.install-box {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-sm) var(--space-md);
+  transition: all var(--transition-base);
+}
+
+.install-box:hover {
+  border-color: var(--color-purple);
+  box-shadow: 0 0 20px rgba(139, 92, 246, 0.15);
+}
+
+.install-box code {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--color-text);
+  background: none;
+  padding: 0;
+  user-select: all;
+}
+
+.install-copy {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: var(--color-bg-card-hover);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.install-copy:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
+  border-color: var(--color-border-subtle);
+}
+
+.install-copy.copied {
+  background: rgba(34, 197, 94, 0.15);
+  border-color: rgba(34, 197, 94, 0.3);
+  color: var(--color-green);
+}
+
 /* Terminal */
 .hero-terminal {
   margin-top: var(--space-3xl);
@@ -1504,6 +1574,18 @@ body {
 
   .section-title {
     font-size: 28px;
+  }
+
+  .install-box {
+    flex-direction: column;
+    padding: var(--space-md);
+    gap: var(--space-md);
+  }
+
+  .install-box code {
+    font-size: 12px;
+    word-break: break-all;
+    text-align: center;
   }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# RunbookAI Install Script
+# Usage: curl -fsSL https://userunbook.ai/install.sh | bash
+#
+# This script installs RunbookAI, an AI-powered SRE assistant.
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+# Configuration
+REPO_URL="https://github.com/Runbook-Agent/RunbookAI.git"
+INSTALL_DIR="${RUNBOOK_INSTALL_DIR:-$HOME/.runbook}"
+BIN_DIR="${RUNBOOK_BIN_DIR:-$HOME/.local/bin}"
+
+# Banner
+print_banner() {
+    echo -e "${PURPLE}"
+    echo ' ____              _                 _       _    ___ '
+    echo '|  _ \ _   _ _ __ | |__   ___   ___ | | __  / \  |_ _|'
+    echo '| |_) | | | | '\''_ \| '\''_ \ / _ \ / _ \| |/ / / _ \  | | '
+    echo '|  _ <| |_| | | | | |_) | (_) | (_) |   < / ___ \ | | '
+    echo '|_| \_\\__,_|_| |_|_.__/ \___/ \___/|_|\_/_/   \_\___|'
+    echo -e "${NC}"
+    echo -e "${CYAN}          Your AI SRE, always on call${NC}"
+    echo ""
+}
+
+info() {
+    echo -e "${BLUE}::${NC} $1"
+}
+
+success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}!${NC} $1"
+}
+
+error() {
+    echo -e "${RED}✗${NC} $1"
+    exit 1
+}
+
+# Detect OS and architecture
+detect_platform() {
+    OS="$(uname -s)"
+    ARCH="$(uname -m)"
+
+    case "$OS" in
+        Linux*)     OS=linux;;
+        Darwin*)    OS=darwin;;
+        MINGW*|MSYS*|CYGWIN*) OS=windows;;
+        *)          error "Unsupported operating system: $OS";;
+    esac
+
+    case "$ARCH" in
+        x86_64|amd64)   ARCH=x64;;
+        arm64|aarch64)  ARCH=arm64;;
+        *)              error "Unsupported architecture: $ARCH";;
+    esac
+
+    info "Detected platform: $OS-$ARCH"
+}
+
+# Check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Install Bun if not present
+install_bun() {
+    if command_exists bun; then
+        success "Bun is already installed ($(bun --version))"
+        return 0
+    fi
+
+    info "Installing Bun..."
+    curl -fsSL https://bun.sh/install | bash
+
+    # Source bun for current session
+    export BUN_INSTALL="$HOME/.bun"
+    export PATH="$BUN_INSTALL/bin:$PATH"
+
+    if command_exists bun; then
+        success "Bun installed successfully ($(bun --version))"
+    else
+        error "Failed to install Bun. Please install it manually: https://bun.sh"
+    fi
+}
+
+# Check for git
+check_git() {
+    if ! command_exists git; then
+        error "Git is required but not installed. Please install git first."
+    fi
+    success "Git is installed"
+}
+
+# Clone or update repository
+install_runbook() {
+    if [ -d "$INSTALL_DIR" ]; then
+        info "Updating existing installation..."
+        cd "$INSTALL_DIR"
+        git fetch origin main
+        git reset --hard origin/main
+        success "Updated to latest version"
+    else
+        info "Cloning RunbookAI..."
+        git clone --depth 1 "$REPO_URL" "$INSTALL_DIR"
+        success "Cloned repository"
+    fi
+
+    cd "$INSTALL_DIR"
+
+    info "Installing dependencies..."
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    success "Dependencies installed"
+
+    info "Building CLI..."
+    bun run build
+    success "Build complete"
+}
+
+# Setup PATH
+setup_path() {
+    # Create bin directory if needed
+    mkdir -p "$BIN_DIR"
+
+    # Create symlink
+    ln -sf "$INSTALL_DIR/dist/cli.js" "$BIN_DIR/runbook"
+    chmod +x "$BIN_DIR/runbook"
+    success "Created symlink at $BIN_DIR/runbook"
+
+    # Check if BIN_DIR is in PATH
+    if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+        warn "$BIN_DIR is not in your PATH"
+
+        # Detect shell and config file
+        SHELL_NAME="$(basename "$SHELL")"
+        case "$SHELL_NAME" in
+            bash)
+                SHELL_CONFIG="$HOME/.bashrc"
+                [ -f "$HOME/.bash_profile" ] && SHELL_CONFIG="$HOME/.bash_profile"
+                ;;
+            zsh)
+                SHELL_CONFIG="$HOME/.zshrc"
+                ;;
+            fish)
+                SHELL_CONFIG="$HOME/.config/fish/config.fish"
+                ;;
+            *)
+                SHELL_CONFIG=""
+                ;;
+        esac
+
+        if [ -n "$SHELL_CONFIG" ]; then
+            echo "" >> "$SHELL_CONFIG"
+            echo "# RunbookAI" >> "$SHELL_CONFIG"
+            echo "export PATH=\"$BIN_DIR:\$PATH\"" >> "$SHELL_CONFIG"
+            success "Added $BIN_DIR to PATH in $SHELL_CONFIG"
+            echo ""
+            info "Run this to use runbook in current session:"
+            echo -e "    ${BOLD}export PATH=\"$BIN_DIR:\$PATH\"${NC}"
+        else
+            echo ""
+            info "Add this to your shell config:"
+            echo -e "    ${BOLD}export PATH=\"$BIN_DIR:\$PATH\"${NC}"
+        fi
+    fi
+}
+
+# Print next steps
+print_next_steps() {
+    echo ""
+    echo -e "${GREEN}${BOLD}Installation complete!${NC}"
+    echo ""
+    echo -e "${BOLD}Next steps:${NC}"
+    echo ""
+    echo "  1. Set your Anthropic API key:"
+    echo -e "     ${CYAN}export ANTHROPIC_API_KEY=your-api-key${NC}"
+    echo ""
+    echo "  2. Create a config file:"
+    echo -e "     ${CYAN}mkdir -p .runbook && cp $INSTALL_DIR/examples/config.yaml .runbook/config.yaml${NC}"
+    echo ""
+    echo "  3. Ask your first question:"
+    echo -e "     ${CYAN}runbook ask \"What EC2 instances are running?\"${NC}"
+    echo ""
+    echo -e "${BOLD}Documentation:${NC} https://userunbook.ai/docs.html"
+    echo -e "${BOLD}GitHub:${NC}        https://github.com/Runbook-Agent/RunbookAI"
+    echo ""
+}
+
+# Main installation flow
+main() {
+    print_banner
+
+    detect_platform
+    check_git
+    install_bun
+    install_runbook
+    setup_path
+    print_next_steps
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `install.sh` for easy installation via a single curl command
- Add prominent install command section to the homepage with copy-to-clipboard
- Add CNAME file for `userunbook.ai` custom domain
- Update canonical URLs from `runbook-agent.github.io` to `userunbook.ai`

## Install Command

```bash
curl -fsSL https://userunbook.ai/install.sh | bash
```

## What the script does

1. Detects OS and architecture (Linux/macOS, x64/arm64)
2. Checks for Git
3. Installs Bun if not present
4. Clones the repo to `~/.runbook`
5. Runs `bun install` and `bun run build`
6. Creates symlink at `~/.local/bin/runbook`
7. Adds to PATH in shell config if needed

## Screenshot

The homepage now shows the install command prominently below the CTA buttons.

## Test plan

- [ ] Test install script on macOS (arm64)
- [ ] Test install script on macOS (x64)
- [ ] Test install script on Linux (x64)
- [ ] Verify homepage shows install command correctly
- [ ] Verify copy-to-clipboard works
- [ ] Verify CNAME works for GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)