### PR TITLE
Add design-partner intake flow and 3-step onboarding path

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -68,6 +68,7 @@
           <ul class="sidebar-nav">
             <li><a href="#installation" class="active">Installation</a></li>
             <li><a href="#configuration">Configuration</a></li>
+            <li><a href="#aws-k8s-pagerduty-slack">3-Step AWS+K8s Path</a></li>
             <li><a href="#first-query">First Query</a></li>
           </ul>
         </div>
@@ -265,6 +266,34 @@ server:
   # Server: configure the server itself
   port: 4000
   host: 0.0.0.0</code></pre>
+        </div>
+
+        <h2 id="aws-k8s-pagerduty-slack">Opinionated Onboarding: AWS + Kubernetes + PagerDuty + Slack</h2>
+        <p>Use this path if you want the fastest practical production setup for one on-call team.</p>
+
+        <h3>Step 1: Install the CLI and verify cloud/cluster access</h3>
+        <p>Install RunbookAI, then validate AWS identity and Kubernetes connectivity. Reference: <a href="#installation">Installation</a>, <a href="#aws">AWS integration</a>, <a href="#kubernetes">Kubernetes integration</a>.</p>
+        <div class="config-block">
+          <div class="config-header">Terminal</div>
+          <pre><code>npm install -g @runbook-agent/runbook
+aws sts get-caller-identity
+kubectl config current-context</code></pre>
+        </div>
+
+        <h3>Step 2: Run setup wizard with this integration profile</h3>
+        <p>Run the wizard and enable AWS, Kubernetes, PagerDuty, and Slack when prompted. Reference: <a href="#configuration">Configuration</a>, <a href="#pagerduty">PagerDuty</a>, <a href="#slack">Slack</a>.</p>
+        <div class="config-block">
+          <div class="config-header">Terminal</div>
+          <pre><code>runbook init</code></pre>
+        </div>
+
+        <h3>Step 3: Validate incident workflow end to end</h3>
+        <p>Verify infra access, investigate a PagerDuty incident, and start Slack intake. Reference: <a href="#status">runbook status</a>, <a href="#investigate">runbook investigate</a>, <a href="#slack-gateway">runbook slack-gateway</a>.</p>
+        <div class="config-block">
+          <div class="config-header">Terminal</div>
+          <pre><code>runbook status
+runbook investigate PD-12345
+runbook slack-gateway --mode socket</code></pre>
         </div>
 
         <!-- First Query -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,6 +53,8 @@
         <div class="nav-links">
           <a href="docs.html" class="nav-link">Docs</a>
           <a href="security.html" class="nav-link">Safety</a>
+          <a href="docs.html#aws-k8s-pagerduty-slack" class="nav-link">3-Step Onboarding</a>
+          <a href="#design-partner" class="nav-link">Design Partners</a>
           <a href="https://github.com/Runbook-Agent/RunbookAI" class="nav-link nav-link-gh" target="_blank" rel="noopener">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
             GitHub
@@ -74,6 +76,8 @@
     <div class="mobile-menu" id="mobile-menu">
       <a href="docs.html">Docs</a>
       <a href="security.html">Safety & Control</a>
+      <a href="docs.html#aws-k8s-pagerduty-slack">3-Step Onboarding</a>
+      <a href="#design-partner">Design Partners</a>
       <a href="https://github.com/Runbook-Agent/RunbookAI" target="_blank" rel="noopener">GitHub</a>
       <a href="#demo" class="nav-cta">Try the Demo</a>
     </div>
@@ -96,9 +100,14 @@
         </h1>
 
         <p class="hero-subtitle" data-reveal>
-          RunbookAI investigates production incidents like your best on-call engineer —
-          forming hypotheses, gathering evidence, and driving to root cause.
-          <a href="security.html" style="color: var(--purple); text-decoration: none; font-weight: 500;">Approval gates, audit trails</a>, and cross-system context built in.
+          RunbookAI investigates production incidents like your best on-call engineer:
+          forms hypotheses, gathers evidence, and drives to root cause with recommended fixes.
+          Built for production ops with <a href="security.html" style="color: var(--purple); text-decoration: none; font-weight: 500;">approval gates, audit trails</a>, and cross-system context.
+        </p>
+
+        <p class="hero-proof" data-reveal>
+          Proven workflow in the demo: ranked hypotheses with confidence scores, full evidence traces,
+          and remediation steps your team can approve in channel.
         </p>
 
         <div class="hero-actions" data-reveal>
@@ -106,8 +115,8 @@
             Try the Demo
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
-          <a href="https://github.com/Runbook-Agent/RunbookAI" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">
-            View on GitHub
+          <a href="#design-partner" class="btn btn-secondary btn-lg">
+            Join as Design Partner
           </a>
         </div>
 
@@ -403,6 +412,77 @@
       </div>
     </section>
 
+    <!-- Conversion Paths -->
+    <section class="pathways" id="start-paths">
+      <div class="container">
+        <div class="section-header" data-reveal-section>
+          <span class="section-tag">Start Here</span>
+          <h2 class="section-title">Pick your path in under 60 seconds</h2>
+        </div>
+
+        <div class="pathways-grid">
+          <div class="pathway-card" data-reveal-section>
+            <span class="cap-label">Design Partner</span>
+            <h3>Share your stack and incident pain</h3>
+            <p>Tell us your role, infra setup, top incident pain, and how to reach you. We use this to prioritize roadmap work.</p>
+            <a href="#design-partner" class="btn btn-secondary">Open intake form</a>
+          </div>
+
+          <div class="pathway-card" data-reveal-section>
+            <span class="cap-label">Onboarding</span>
+            <h3>Use the AWS + Kubernetes + PagerDuty + Slack path</h3>
+            <p>Follow an opinionated 3-step setup sequence with exact commands and links to the right docs sections.</p>
+            <a href="docs.html#aws-k8s-pagerduty-slack" class="btn btn-secondary">Open 3-step onboarding</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Design Partner -->
+    <section class="design-partner" id="design-partner">
+      <div class="container">
+        <div class="section-header" data-reveal-section>
+          <span class="section-tag">Design Partner Program</span>
+          <h2 class="section-title">Tell us where incidents hurt</h2>
+        </div>
+
+        <div class="design-partner-layout" data-reveal-section>
+          <div class="design-partner-copy">
+            <p>We are onboarding a small number of teams running production workloads on AWS and Kubernetes. Share a few details and we will follow up with a focused setup session.</p>
+            <p>If the form submit does not open your mail app, use the fallback link below.</p>
+          </div>
+
+          <form class="partner-form" id="design-partner-form">
+            <label class="partner-field">
+              Role
+              <input type="text" name="role" placeholder="e.g. Staff SRE" required />
+            </label>
+
+            <label class="partner-field">
+              Infra stack
+              <textarea name="infraStack" rows="2" placeholder="e.g. EKS, RDS, ElastiCache, Datadog" required></textarea>
+            </label>
+
+            <label class="partner-field">
+              Incident pain
+              <textarea name="incidentPain" rows="3" placeholder="e.g. Noisy alerts and slow root cause analysis" required></textarea>
+            </label>
+
+            <label class="partner-field">
+              Contact
+              <input type="text" name="contact" placeholder="email, Slack handle, or LinkedIn" required />
+            </label>
+
+            <div class="partner-actions">
+              <button type="submit" class="btn btn-primary">Send via email</button>
+              <a href="mailto:design-partners@userunbook.ai?subject=RunbookAI%20Design%20Partner" class="btn btn-ghost">Mailto fallback</a>
+            </div>
+            <p class="partner-status" id="design-partner-status" aria-live="polite"></p>
+          </form>
+        </div>
+      </div>
+    </section>
+
     <!-- Final CTA -->
     <section class="cta">
       <div class="container">
@@ -414,8 +494,8 @@
               Try the Demo
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
             </a>
-            <a href="https://github.com/Runbook-Agent/RunbookAI" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">
-              View on GitHub
+            <a href="#design-partner" class="btn btn-secondary btn-lg">
+              Become a Design Partner
             </a>
             <a href="security.html" class="btn btn-ghost btn-lg">
               Review Safety Model
@@ -452,8 +532,10 @@
               <h4>Product</h4>
               <a href="docs.html">Docs</a>
               <a href="security.html">Safety & Control</a>
+              <a href="docs.html#aws-k8s-pagerduty-slack">3-Step Onboarding</a>
               <a href="#features">Features</a>
               <a href="#integrations">Integrations</a>
+              <a href="#design-partner">Design Partners</a>
             </div>
             <div class="footer-column">
               <h4>Resources</h4>

--- a/docs/script.js
+++ b/docs/script.js
@@ -40,6 +40,8 @@ function copyToClipboard(button) {
 // ========================================
 
 document.addEventListener('DOMContentLoaded', () => {
+  initDesignPartnerForm();
+
   // Register GSAP plugins
   if (typeof gsap !== 'undefined' && typeof ScrollTrigger !== 'undefined') {
     gsap.registerPlugin(ScrollTrigger);
@@ -138,6 +140,44 @@ document.addEventListener('DOMContentLoaded', () => {
     updateActiveLink();
   }
 });
+
+function initDesignPartnerForm() {
+  const form = document.getElementById('design-partner-form');
+  if (!form) return;
+
+  const status = document.getElementById('design-partner-status');
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const role = String(formData.get('role') || '').trim();
+    const infraStack = String(formData.get('infraStack') || '').trim();
+    const incidentPain = String(formData.get('incidentPain') || '').trim();
+    const contact = String(formData.get('contact') || '').trim();
+
+    const subjectRole = role || 'RunbookAI Design Partner';
+    const subject = `RunbookAI Design Partner: ${subjectRole}`;
+    const body = [
+      'Design Partner Intake',
+      '',
+      `Role: ${role}`,
+      `Infra stack: ${infraStack}`,
+      `Incident pain: ${incidentPain}`,
+      `Contact: ${contact}`,
+      '',
+      'Submitted from userunbook.ai'
+    ].join('\n');
+
+    const mailtoUrl = `mailto:design-partners@userunbook.ai?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+
+    if (status) {
+      status.textContent = 'Opening your email client...';
+    }
+
+    window.location.href = mailtoUrl;
+  });
+}
 
 function initAnimations() {
   // Accessibility: skip all animations for reduced-motion users

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1029,6 +1029,136 @@ body {
 }
 
 /* ========================================
+   CONVERSION PATHS
+   ======================================== */
+
+.pathways {
+  position: relative;
+  z-index: 1;
+  padding: var(--space-5xl) 0;
+}
+
+.pathways-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-lg);
+}
+
+.pathway-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-xl);
+  box-shadow: var(--shadow-sm);
+}
+
+.pathway-card h3 {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  margin-bottom: var(--space-sm);
+}
+
+.pathway-card p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: var(--space-md);
+}
+
+/* ========================================
+   DESIGN PARTNER FORM
+   ======================================== */
+
+.design-partner {
+  position: relative;
+  z-index: 1;
+  padding: var(--space-5xl) 0;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.design-partner-layout {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: var(--space-xl);
+  align-items: start;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-xl);
+  box-shadow: var(--shadow-sm);
+}
+
+.design-partner-copy p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: var(--space-md);
+}
+
+.partner-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.partner-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.partner-field input,
+.partner-field textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  color: var(--text);
+  padding: 10px 12px;
+  font-family: var(--font);
+  font-size: 14px;
+  line-height: 1.5;
+  transition: border-color var(--duration) var(--ease), box-shadow var(--duration) var(--ease);
+}
+
+.partner-field textarea {
+  resize: vertical;
+  min-height: 92px;
+}
+
+.partner-field input:focus,
+.partner-field textarea:focus {
+  outline: none;
+  border-color: var(--purple);
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+}
+
+.partner-field input::placeholder,
+.partner-field textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.partner-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: 4px;
+}
+
+.partner-status {
+  min-height: 20px;
+  margin-bottom: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* ========================================
    TERMINAL (shared)
    ======================================== */
 
@@ -1305,6 +1435,14 @@ body {
     padding: var(--space-xl);
   }
 
+  .pathways-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .design-partner-layout {
+    grid-template-columns: 1fr;
+  }
+
   .footer-content {
     grid-template-columns: 1fr;
     gap: var(--space-xl);
@@ -1382,6 +1520,9 @@ body {
     width: 100%;
   }
 
+  .partner-actions .btn {
+    width: 100%;
+  }
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
- add lightweight design-partner capture flow on homepage (role, infra stack, incident pain, contact) with mailto fallback
- add clear discovery links (nav/mobile/footer + start-here section)
- add opinionated AWS + Kubernetes + PagerDuty + Slack onboarding section with first 3 steps
- keep changes scoped to docs site files only

## Files
- docs/index.html
- docs/styles.css
- docs/script.js
- docs/docs.html